### PR TITLE
Force disconnect on read or write error

### DIFF
--- a/FINSApp/src/Makefile
+++ b/FINSApp/src/Makefile
@@ -11,6 +11,8 @@ LIBRARY_IOC += FINS
 # xxxRecord.dbd will be installed into <top>/dbd
 DBD += finsUDP.dbd
 
+USR_CFLAGS_WIN32 += -D_WINSOCK_DEPRECATED_NO_WARNINGS
+
 # The following are compiled and added to the support library
 FINS_SRCS += finsUDP.c
 #FINS_SRCS += finsHostlink.c

--- a/FINSApp/src/finsUDP.c
+++ b/FINSApp/src/finsUDP.c
@@ -770,6 +770,7 @@ static asynStatus adisconnect(void *pvt, asynUser *pasynUser)
 		shutdown(pdrvPvt->fd, SHUT_RDWR);
 		epicsSocketDestroy(pdrvPvt->fd);
 		pdrvPvt->fd = epicsSocketCreate(PF_INET, SOCK_STREAM, 0);
+        errlogSevPrintf(errlogInfo, "%s finsUDP:disconnect\n", pdrvPvt->portName);
 	}
 	pdrvPvt->connected = 0;
 	pasynManager->exceptionDisconnect(pasynUser);
@@ -2023,6 +2024,7 @@ static asynStatus socketRead(void *pvt, asynUser *pasynUser, char *data, size_t 
 
 	if (finsSocketRead(pdrvPvt, pasynUser, (void *) data, maxchars, addr, nbytesTransfered, 0) < 0)
 	{
+        adisconnect(pdrvPvt, pasynUser);
 		return (asynError);
 	}
 	
@@ -2093,6 +2095,7 @@ static asynStatus socketWrite(void *pvt, asynUser *pasynUser, const char *data, 
 	
 	if (finsSocketWrite(pdrvPvt, pasynUser, (void *) data, numchars, addr, 0) < 0)
 	{
+        adisconnect(pdrvPvt, pasynUser);
 		return (asynError);
 	}
 

--- a/FINSApp/src/finsUDP.c
+++ b/FINSApp/src/finsUDP.c
@@ -1149,7 +1149,6 @@ static int finsSocketRead(drvPvt *pdrvPvt, asynUser *pasynUser, void *data, cons
 	
 	if ( pdrvPvt->tcp_protocol && (send_fins_header(&fins_header, pdrvPvt->fd, pdrvPvt->portName, pasynUser, sendlen, 0) < 0) )
 	{
-		asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s: port %s, send_fins_header() failed.\n", FUNCNAME, pdrvPvt->portName); 
         return (-1);
 	}
 	
@@ -1211,7 +1210,6 @@ static int finsSocketRead(drvPvt *pdrvPvt, asynUser *pasynUser, void *data, cons
 		errno = 0;		
 		if ( pdrvPvt->tcp_protocol && (recv_fins_header(&fins_header, pdrvPvt->fd, pdrvPvt->portName, pasynUser, 0) < 0) )
 		{
-			asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s: port %s, recv_fins_header() failed.\n", FUNCNAME, pdrvPvt->portName);		    
             return (-1);
 		}
 		if ((recvlen = socket_recv(pdrvPvt->fd, pdrvPvt->reply, FINS_MAX_MSG, 0)) < 0)
@@ -1849,7 +1847,6 @@ static int finsSocketWrite(drvPvt *pdrvPvt, asynUser *pasynUser, const void *dat
 	
 	if ( pdrvPvt->tcp_protocol && (send_fins_header(&fins_header, pdrvPvt->fd, pdrvPvt->portName, pasynUser, sendlen, 0) < 0) )
 	{
-		asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s: port %s, send_fins_header() failed.\n", FUNCNAME, pdrvPvt->portName);
  		return (-1);
 	}
 	if (send(pdrvPvt->fd, pdrvPvt->message, sendlen, 0) != sendlen)
@@ -1909,7 +1906,6 @@ static int finsSocketWrite(drvPvt *pdrvPvt, asynUser *pasynUser, const void *dat
 
 	    if ( pdrvPvt->tcp_protocol && (recv_fins_header(&fins_header, pdrvPvt->fd, pdrvPvt->portName, pasynUser, 0) < 0) )
 	    {
-			asynPrint(pasynUser, ASYN_TRACE_ERROR, "%s: port %s, recv_fins_header() failed.\n", FUNCNAME, pdrvPvt->portName);
 		    return (-1);
 	    }
 		if ((recvlen = socket_recv(pdrvPvt->fd, pdrvPvt->reply, FINS_MAX_MSG, 0)) < 0)


### PR DESCRIPTION
Disconnect from PLC on read or write error, asyn should then reconnect on next attempt. Needs to be checked with a real PLC by e.g. disrupting network connection or resetting plc

See ISISComputingGroup/IBEX#2103
